### PR TITLE
fix: use PAT for release creation to trigger publish workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -87,3 +87,4 @@ jobs:
           tag: v${{ steps.version.outputs.new_version }}
           commit: main
           generateReleaseNotes: true
+          token: ${{ secrets.RELEASE_TOKEN }}


### PR DESCRIPTION
Events created by the default GITHUB_TOKEN don't trigger other workflows. Use a PAT (RELEASE_TOKEN secret) so the release event properly triggers publish.yml.