### PR TITLE
fix: remove unnecessary bot-author skip check from release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,18 +18,7 @@ jobs:
           ref: main
           fetch-depth: 2
 
-      - name: Check if last commit is a version bump (prevent loops)
-        id: check
-        run: |
-          last_author=$(git log -1 --format='%an')
-          if [ "$last_author" = "github-actions[bot]" ]; then
-            echo "skip=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "skip=false" >> "$GITHUB_OUTPUT"
-          fi
-
       - name: Determine bump type from PR
-        if: steps.check.outputs.skip == 'false'
         id: bump
         run: |
           PR_TITLE="${{ github.event.pull_request.title }}"
@@ -44,7 +33,6 @@ jobs:
           fi
 
       - name: Bump version in pyproject.toml
-        if: steps.check.outputs.skip == 'false'
         id: version
         run: |
           python3 -c "
@@ -72,7 +60,6 @@ jobs:
           echo "new_version=$(cat /tmp/new_version)" >> "$GITHUB_OUTPUT"
 
       - name: Commit version bump
-        if: steps.check.outputs.skip == 'false'
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
@@ -81,7 +68,6 @@ jobs:
           git push origin main
 
       - name: Create GitHub release
-        if: steps.check.outputs.skip == 'false'
         uses: ncipollo/release-action@v1
         with:
           tag: v${{ steps.version.outputs.new_version }}


### PR DESCRIPTION
The skip check prevented release creation on workflow reruns — after the version bump commit, the last author is github-actions[bot], so the rerun skips everything including the release step.

This check is unnecessary because the workflow triggers on pull_request (not push), so the version bump commit can never re-trigger it.