### PR TITLE
fix: prevent script injection in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,10 +20,10 @@ jobs:
 
       - name: Determine bump type from PR
         id: bump
+        env:
+          PR_TITLE: ${{ github.event.pull_request.title }}
+          PR_BODY: ${{ github.event.pull_request.body }}
         run: |
-          PR_TITLE="${{ github.event.pull_request.title }}"
-          PR_BODY="${{ github.event.pull_request.body }}"
-
           if echo "$PR_TITLE" | grep -qi '^feat' && echo "$PR_BODY" | grep -qi 'BREAKING CHANGE'; then
             echo "type=major" >> "$GITHUB_OUTPUT"
           elif echo "$PR_TITLE" | grep -qi '^feat'; then


### PR DESCRIPTION
## Summary

- Fix release workflow failure caused by PR body markdown being interpreted as shell commands
- Move `PR_TITLE` and `PR_BODY` from inline `${{ }}` interpolation to the `env:` block, per [GitHub security hardening guidelines](https://docs.github.com/en/actions/security-for-github-actions/security-guides/security-hardening-for-github-actions#using-an-intermediate-environment-variable)

## Context

After merging PR #6, the release action [failed](https://github.com/agupta01/modalflow/actions/runs/22683962811/job/65761745374) because the PR body contained backticks and words like `local`, `modalflow`, and `volume` that bash tried to execute as commands.

## Test plan

- [x] Verified the workflow YAML is valid
- [x] Merge this PR and confirm the release action succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)