### PR TITLE
feat: add task log support for Airflow UI

### DIFF
--- a/src/modalflow/executor/modal_executor.py
+++ b/src/modalflow/executor/modal_executor.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
+import logging
 import os
+from pathlib import Path
 from typing import TYPE_CHECKING, Any, Dict, List, Optional, Sequence, Union
 from urllib.parse import urljoin
 
@@ -12,6 +14,7 @@ from airflow.models.taskinstance import TaskInstanceKey
 
 if TYPE_CHECKING:
     from airflow.executors.workloads import All as ExecutorWorkload
+    from airflow.models.taskinstance import TaskInstance
 
 # Type alias for command - can be a list containing a workload or list of strings
 CommandType = Union[List[executor_workloads.ExecuteTask], List[str]]
@@ -212,11 +215,13 @@ class ModalExecutor(BaseExecutor):
             status = task_state.get("status")
 
             if status == "SUCCESS":
+                self._write_task_log(task_state, key)
                 self.success(key)
                 completed_keys.append(task_key_str)
                 self.log.info(f"Task {task_key_str} succeeded")
 
             elif status == "FAILED":
+                self._write_task_log(task_state, key)
                 self.fail(key)
                 completed_keys.append(task_key_str)
                 error_msg = task_state.get("error", "Unknown error")
@@ -234,6 +239,63 @@ class ModalExecutor(BaseExecutor):
                 self._state_dict.pop(k)
             except Exception as e:
                 self.log.warning(f"Failed to cleanup remote state for {k}: {e}") 
+
+    def get_task_log(self, ti: TaskInstance, try_number: int) -> tuple[list[str], list[str]]:
+        """Return partial logs from state_dict for running tasks.
+
+        Called by FileTaskHandler when ti.state == RUNNING.  Once the task
+        completes, full logs are read from the local filesystem (written by
+        ``_write_task_log`` during ``sync()``).
+        """
+        task_key_str = self._get_key_str(ti.key)
+        try:
+            task_state = self._state_dict.get(task_key_str)
+        except Exception:
+            return [], []
+        if task_state and task_state.get("stdout"):
+            return (
+                [f"Modal task output for {task_key_str}"],
+                [task_state["stdout"]],
+            )
+        return [f"Task {task_key_str} running on Modal"], ["Waiting for output..."]
+
+    def _write_task_log(self, task_state: dict, key: TaskInstanceKey) -> None:
+        """Write task log content from state_dict to the local base_log_folder.
+
+        This makes ``FileTaskHandler._read_from_local()`` work for completed
+        tasks even when the Airflow scheduler doesn't share a Modal Volume
+        with the Modal Functions (e.g. local / production deployments).
+        """
+        # Prefer structured log content from the Airflow SDK supervisor,
+        # fall back to raw stdout captured from the subprocess.
+        content = task_state.get("log_content") or task_state.get("stdout") or ""
+        if not content:
+            return
+
+        try:
+            base_log_folder = conf.get("logging", "base_log_folder")
+        except Exception:
+            base_log_folder = "/opt/airflow/logs"
+
+        # Construct the log path to match FileTaskHandler's default template:
+        #   dag_id={dag_id}/run_id={run_id}/task_id={task_id}/attempt={try_number}.log
+        parts = [
+            f"dag_id={key.dag_id}",
+            f"run_id={key.run_id}",
+            f"task_id={key.task_id}",
+        ]
+        if key.map_index >= 0:
+            parts.append(f"map_index={key.map_index}")
+        parts.append(f"attempt={key.try_number}.log")
+        log_rel_path = os.path.join(*parts)
+
+        full_path = Path(base_log_folder) / log_rel_path
+        try:
+            full_path.parent.mkdir(parents=True, exist_ok=True)
+            full_path.write_text(content)
+            self.log.info(f"Wrote task log ({len(content)} bytes) to {full_path}")
+        except Exception as e:
+            self.log.warning(f"Failed to write task log to {full_path}: {e}")
 
     def end(self) -> None:
         """
@@ -263,11 +325,15 @@ class ModalExecutor(BaseExecutor):
     def _get_key_str(self, key: TaskInstanceKey) -> str:
         """
         Serialize TaskInstanceKey to a string.
-        Format: dag_id:task_id:run_id:try_number
+        Format: dag_id:task_id:run_id:try_number[:map_index]
+
+        map_index is included only for mapped tasks (>= 0) to avoid
+        collisions in state_dict and active_tasks.
         """
-        # Note: TaskInstanceKey is a named tuple, but the fields vary slightly by Airflow version
-        # We construct a stable string key
-        return f"{key.dag_id}:{key.task_id}:{key.run_id}:{key.try_number}"
+        base = f"{key.dag_id}:{key.task_id}:{key.run_id}:{key.try_number}"
+        if key.map_index >= 0:
+            return f"{base}:{key.map_index}"
+        return base
 
     def _resolve_execution_api_url(self) -> str:
         """

--- a/src/modalflow/modal_app.py
+++ b/src/modalflow/modal_app.py
@@ -121,6 +121,16 @@ def execute_modal_task(payload: dict):
     cli_command = payload.get("command")
     env_vars = payload.get("env", {})
 
+    # Extract log_path from workload so we can read the structured log file
+    # written by the Airflow SDK supervisor after execution.
+    log_path = None
+    if workload_json:
+        try:
+            workload_data = json.loads(workload_json)
+            log_path = workload_data.get("log_path")
+        except Exception:
+            pass
+
     print(f"Starting execution for {task_key}")
 
     if workload_json:
@@ -149,39 +159,6 @@ def execute_modal_task(payload: dict):
     run_env = os.environ.copy()
     run_env.update(env_vars)
 
-    # Try to extract task info for logging
-    log_file_path = None
-    try:
-        if workload_json:
-            workload_data = json.loads(workload_json)
-            ti = workload_data.get("ti", {})
-            dag_id = ti.get("dag_id", "unknown")
-            task_id = ti.get("task_id", "unknown")
-            run_id = ti.get("run_id", "unknown")
-            try_number = ti.get("try_number", 1)
-        elif cli_command and len(cli_command) >= 6:
-            # Parse from CLI args: airflow tasks run dag_id task_id run_id ...
-            dag_id = cli_command[3]
-            task_id = cli_command[4]
-            run_id = cli_command[5]
-            try_number = 1
-        else:
-            dag_id = task_id = run_id = "unknown"
-            try_number = 1
-
-        # Construct path: /opt/airflow/logs/dag_id/task_id/run_id/try_number.log
-        log_dir = os.path.join(
-            "/opt/airflow/logs",
-            f"dag_id={dag_id}",
-            f"run_id={run_id}",
-            f"task_id={task_id}",
-        )
-        os.makedirs(log_dir, exist_ok=True)
-        log_file_path = os.path.join(log_dir, f"attempt={try_number}.log")
-        print(f"Writing logs to {log_file_path}")
-    except Exception as e:
-        print(f"Warning: Failed to setup log directory structure: {e}")
-
     # Update state to RUNNING right before execution
     state_dict[task_key] = {
         "status": "RUNNING",
@@ -205,22 +182,28 @@ def execute_modal_task(payload: dict):
         print(f"STDOUT:\n{result.stdout}")
         print(f"STDERR:\n{result.stderr}")
 
-        # Write output to the log file on the volume
-        if log_file_path:
-            try:
-                with open(log_file_path, "w") as f:
-                    f.write(f"*** STDOUT ***\n{result.stdout}\n")
-                    f.write(f"*** STDERR ***\n{result.stderr}\n")
-            except Exception as e:
-                print(f"Failed to write log file: {e}")
-
         status = "SUCCESS" if result.returncode == 0 else "FAILED"
+
+        # Try to read the structured log file written by the Airflow SDK
+        # supervisor.  This contains properly formatted task logs.
+        log_content = ""
+        if log_path:
+            log_file = os.path.join("/opt/airflow/logs", log_path)
+            try:
+                with open(log_file) as f:
+                    log_content = f.read()
+                print(f"Read {len(log_content)} bytes from {log_file}")
+            except FileNotFoundError:
+                print(f"Log file not found at {log_file}, will use stdout")
+            except Exception as e:
+                print(f"Failed to read log file {log_file}: {e}")
 
         state_dict[task_key] = {
             "status": status,
             "return_code": result.returncode,
-            "stdout": result.stdout[-2000:],  # Store last 2KB for quick debug
+            "stdout": result.stdout,
             "stderr": result.stderr[-2000:],
+            "log_content": log_content,
         }
 
     except Exception as e:

--- a/tests/system/helpers.py
+++ b/tests/system/helpers.py
@@ -28,6 +28,12 @@ def start_airflow_and_wait_ready(sandbox: modal.Sandbox, timeout: int = 180) -> 
     execution_api_url = f"{tunnel_url}/execution/"
     print(f"Execution API tunnel URL: {execution_api_url}")
 
+    # Fix permissions on the volume-mounted logs directory so the airflow user
+    # (uid 50000) can write dag-processor and task logs.  Modal FUSE volumes
+    # don't support chown, but chmod 777 makes the directory world-writable.
+    chmod_proc = sandbox.exec("chmod", "777", "/opt/airflow/logs")
+    chmod_proc.wait()
+
     # Start airflow standalone as a foreground exec.  We tee output to a log
     # file so we can grep it for the readiness signal, while still keeping
     # the exec's stdout pipe alive (Modal uses active pipe I/O to determine
@@ -46,6 +52,16 @@ def start_airflow_and_wait_ready(sandbox: modal.Sandbox, timeout: int = 180) -> 
     def _drain():
         for line in _airflow_proc.stdout:
             print(line, end="")
+            # Capture admin password from "Password for user 'admin': <pw>"
+            if "Password for user" in line and "admin" in line:
+                parts = line.strip().rsplit(":", 1)
+                if len(parts) == 2:
+                    pw = parts[1].strip()
+                    # Write to a known location so get_task_logs() can read it
+                    pw_proc = sandbox.exec(
+                        "bash", "-c", f"echo '{pw}' > /tmp/admin_password.txt",
+                    )
+                    pw_proc.wait()
             if "Airflow is ready" in line:
                 ready_event.set()
 
@@ -216,6 +232,47 @@ def wait_for_dag_run(
     raise TimeoutError(
         f"DAG run {dag_id}/{run_id} did not complete within {timeout}s"
     )
+
+
+def get_task_logs(
+    sandbox: modal.Sandbox,
+    dag_id: str,
+    run_id: str,
+    task_id: str,
+    try_number: int = 1,
+) -> str:
+    """Fetch task logs via the Airflow REST API (same endpoint the UI uses).
+
+    Returns:
+        The log content string.
+
+    Raises:
+        RuntimeError: If the API call fails.
+    """
+    # Read the admin password saved during start_airflow_and_wait_ready()
+    proc = sandbox.exec("bash", "-c", "cat /tmp/admin_password.txt 2>/dev/null || echo ''")
+    password = ""
+    for line in proc.stdout:
+        password = line.strip()
+    proc.wait()
+
+    if not password:
+        raise RuntimeError("Could not read standalone admin password")
+
+    api_url = (
+        f"http://localhost:8080/api/v2/dags/{dag_id}/dagRuns/{run_id}"
+        f"/taskInstances/{task_id}/logs/{try_number}"
+    )
+    proc = sandbox.exec(
+        "bash", "-c",
+        f'curl -s -u "admin:{password}" "{api_url}"',
+    )
+    lines = []
+    for line in proc.stdout:
+        lines.append(line)
+    proc.wait()
+
+    return "".join(lines)
 
 
 def get_task_states(

--- a/tests/system/test_app.py
+++ b/tests/system/test_app.py
@@ -42,6 +42,9 @@ airflow_test_image = (
 app = modal.App("modalflow-test-runner", image=airflow_test_image)
 
 
+log_volume = modal.Volume.from_name("airflow-logs-main", create_if_missing=True)
+
+
 def create_test_sandbox() -> modal.Sandbox:
     """
     Create a Sandbox for running airflow standalone tests.
@@ -59,6 +62,7 @@ def create_test_sandbox() -> modal.Sandbox:
         image=airflow_test_image,
         secrets=[modal.Secret.from_name("modal")],
         encrypted_ports=[8080],
+        volumes={"/opt/airflow/logs": log_volume},
         name="modalflow-system-runner",
         timeout=3600,
     )
@@ -89,7 +93,7 @@ def start_airflow(sandbox: modal.Sandbox) -> None:
 # E2E test classes (run via pytest)
 # ---------------------------------------------------------------------------
 
-from helpers import unpause_dag, trigger_dag, wait_for_dag_run, get_task_states
+from helpers import unpause_dag, trigger_dag, wait_for_dag_run, get_task_states, get_task_logs
 
 
 class TestBashOperatorE2E:
@@ -106,6 +110,11 @@ class TestBashOperatorE2E:
             for t in tasks
         ), f"echo_hello task not successful: {tasks}"
 
+        # Verify logs are readable via the REST API (same path the UI uses)
+        logs = get_task_logs(sandbox, dag_id, run_id, "echo_hello")
+        assert "Could not read served logs" not in logs, f"Log serving broken: {logs[:500]}"
+        assert len(logs) > 0, "Logs should not be empty"
+
 
 class TestPythonOperatorE2E:
     def test_python_task_succeeds(self, airflow_ready, sandbox):
@@ -121,6 +130,11 @@ class TestPythonOperatorE2E:
             for t in tasks
         ), f"return_value task not successful: {tasks}"
 
+        # Verify logs are readable via the REST API
+        logs = get_task_logs(sandbox, dag_id, run_id, "return_value")
+        assert "Could not read served logs" not in logs, f"Log serving broken: {logs[:500]}"
+        assert len(logs) > 0, "Logs should not be empty"
+
 
 class TestFailurePropagation:
     def test_failing_task_reported(self, airflow_ready, sandbox):
@@ -135,6 +149,11 @@ class TestFailurePropagation:
             t["task_id"] == "fail_task" and t["state"] == "failed"
             for t in tasks
         ), f"fail_task task not failed: {tasks}"
+
+        # Verify logs are readable even for failed tasks
+        logs = get_task_logs(sandbox, dag_id, run_id, "fail_task")
+        assert "Could not read served logs" not in logs, f"Log serving broken: {logs[:500]}"
+        assert len(logs) > 0, "Logs should not be empty"
 
 
 if __name__ == "__main__":

--- a/uv.lock
+++ b/uv.lock
@@ -1737,7 +1737,7 @@ wheels = [
 
 [[package]]
 name = "modalflow"
-version = "0.1.0"
+version = "0.2.4"
 source = { editable = "." }
 dependencies = [
     { name = "apache-airflow" },


### PR DESCRIPTION
## Summary

- **`get_task_log()`** on ModalExecutor returns partial logs from `state_dict` while tasks are RUNNING
- **`_write_task_log()`** writes structured log content (or stdout fallback) to the local `base_log_folder` when tasks complete, so `FileTaskHandler._read_from_local()` works for both local and production deployments
- Modal function reads the Airflow SDK supervisor's structured log file from the volume and stores it in `state_dict`
- Fixes `_get_key_str` to include `map_index` for dynamically mapped tasks, preventing `state_dict`/`active_tasks` key collisions
- Mounts the shared `airflow-logs` volume on the E2E test Sandbox and adds log content assertions to all tests
- Removes redundant manual log file writing from `execute_modal_task` (the SDK supervisor already writes structured logs)

Previously the Airflow UI showed: `Could not read served logs: HTTPConnectionPool(host='modal', port=8793): Max retries exceeded` because `FileTaskHandler` tried to fetch logs from the ephemeral Modal container.

## Test plan

- [x] `make system.setup && make system.test.e2e` — all 3 E2E tests pass (bash success, python success, failure propagation), including new log content assertions
- [x] Verified logs appear in Airflow UI for static tasks via local `airflow standalone` + ngrok
- [x] Verified logs appear for dynamically mapped tasks (map_index handled correctly)

🤖 Generated with [Claude Code](https://claude.com/claude-code)