### PR TITLE
Remove deploy command from CLI (Sandbox migration)

### DIFF
--- a/src/modalflow/cli.py
+++ b/src/modalflow/cli.py
@@ -1,105 +1,11 @@
 import click
-import os
-import subprocess
-import sys
 from pathlib import Path
-
-DAGS_SOURCE_CHOICES = click.Choice(["local", "volume", "cloud-bucket"])
 
 
 @click.group()
 def cli():
     """Modalflow CLI."""
     pass
-
-
-@cli.command()
-@click.option("--env", default="main", help="Target environment name (default: main)")
-@click.option(
-    "--dags-source",
-    type=DAGS_SOURCE_CHOICES,
-    required=True,
-    help="DAG source mode: local (bake into image), volume (Modal Volume), cloud-bucket (S3)",
-)
-@click.option(
-    "--dags-path",
-    type=click.Path(exists=True, file_okay=False, resolve_path=True),
-    help="Local directory containing DAG files (required for local and volume modes)",
-)
-@click.option(
-    "--dags-volume",
-    help="Modal Volume name for DAG storage (required for volume mode)",
-)
-@click.option(
-    "--dags-bucket",
-    help="S3 URI for DAG storage, e.g. s3://bucket/prefix (required for cloud-bucket mode)",
-)
-@click.option(
-    "--dags-bucket-secret",
-    help="Modal Secret name with cloud credentials (required for cloud-bucket mode)",
-)
-@click.option(
-    "--airflow-version",
-    default="3.1.5",
-    show_default=True,
-    help="Apache Airflow version to install in the Modal function image",
-)
-def deploy(env, dags_source, dags_path, dags_volume, dags_bucket, dags_bucket_secret, airflow_version):
-    """
-    Deploy the Modalflow application to the specified environment.
-
-    This deploys the Modal App, Volume, and Dict defined in modal_app.py.
-    """
-    # Validate options per mode
-    if dags_source == "local":
-        if not dags_path:
-            raise click.UsageError("--dags-path is required when --dags-source is 'local'")
-    elif dags_source == "volume":
-        if not dags_path:
-            raise click.UsageError("--dags-path is required when --dags-source is 'volume'")
-        if not dags_volume:
-            raise click.UsageError("--dags-volume is required when --dags-source is 'volume'")
-    elif dags_source == "cloud-bucket":
-        if not dags_bucket:
-            raise click.UsageError("--dags-bucket is required when --dags-source is 'cloud-bucket'")
-        if not dags_bucket_secret:
-            raise click.UsageError(
-                "--dags-bucket-secret is required when --dags-source is 'cloud-bucket'"
-            )
-
-    click.echo(f"Deploying Modalflow to environment: '{env}' (dags-source: {dags_source})...")
-
-    # Build environment variables for modal deploy
-    env_vars = os.environ.copy()
-    env_vars["MODALFLOW_ENV"] = env
-    env_vars["MODALFLOW_AIRFLOW_VERSION"] = airflow_version
-
-    if dags_source == "local":
-        env_vars["MODALFLOW_DAGS_DIR"] = dags_path
-    elif dags_source == "volume":
-        env_vars["MODALFLOW_DAGS_VOLUME"] = dags_volume
-    elif dags_source == "cloud-bucket":
-        env_vars["MODALFLOW_DAGS_BUCKET"] = dags_bucket
-        env_vars["MODALFLOW_DAGS_BUCKET_SECRET"] = dags_bucket_secret
-
-    # Run 'modal deploy' targeting the modal_app module
-    cmd = [sys.executable, "-m", "modal", "deploy", "modalflow.modal_app"]
-
-    try:
-        subprocess.run(cmd, env=env_vars, check=True)
-        click.echo(f"Successfully deployed to environment '{env}'!")
-    except subprocess.CalledProcessError as e:
-        click.echo(f"Deployment failed with exit code {e.returncode}.", err=True)
-        sys.exit(e.returncode)
-    except Exception as e:
-        click.echo(f"An error occurred: {e}", err=True)
-        sys.exit(1)
-
-    # For volume mode, upload DAGs after deploy
-    if dags_source == "volume":
-        click.echo(f"Uploading DAGs to volume '{dags_volume}'...")
-        _sync_dags_to_volume(dags_path, dags_volume)
-        click.echo("DAGs uploaded successfully!")
 
 
 @cli.command()
@@ -116,7 +22,7 @@ def deploy(env, dags_source, dags_path, dags_volume, dags_bucket, dags_bucket_se
 )
 def sync(dags_path, dags_volume):
     """
-    Sync local DAG files to a Modal Volume without redeploying.
+    Sync local DAG files to a Modal Volume.
 
     Performs a full replace: removes existing files from the volume,
     then uploads the local DAG directory.


### PR DESCRIPTION
## Unit 2 — CLI: drop `deploy`, keep volume `sync`

Part of migrating modalflow's backend from Modal **Functions** to Modal **Sandboxes**.

### What changed
- Removed the `modalflow deploy` command, including its `modal deploy modalflow.modal_app` subprocess call, the `--dags-source`/`--dags-path`/`--dags-volume`/`--dags-bucket`/`--dags-bucket-secret`/`--airflow-version`/`--env` options, and the local/volume/cloud-bucket validation branches.
- Removed now-unused imports (`os`, `subprocess`, `sys`) and the `DAGS_SOURCE_CHOICES` constant.
- Kept the `sync` command and `_sync_dags_to_volume()` helper unchanged. The CLI's only job now is pushing DAGs to a Modal Volume (volume-only DAG delivery).

### Why
There is no longer a Modal app to deploy — the executor creates an independent Modal Sandbox per Airflow task on demand.

### Verification
- `uv run modalflow --help` → `deploy` is gone, `sync` remains.

🤖 Generated with [Claude Code](https://claude.com/claude-code)