### PR TITLE
test(system): volume-only DAG flow, drop modal deploy

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,28 +3,27 @@
 build:
 	@uv build
 
-# Set up the Sandbox for system tests
-# This builds the package wheel needed by the Sandbox image
+# DAG volume name used by the per-task execution sandboxes.
+DAG_VOLUME_NAME := test-dags-vol
+
+# Set up the Sandbox for system tests (volume-only DAG loading)
+# This builds the package wheel needed by the Sandbox image and pushes the
+# test DAGs to a Modal Volume that the executor mounts into each task sandbox.
+# There is no longer a deploy step or baked-DAG mode.
 system.setup:
 	@echo "Setting up system test Sandbox..."
 	@echo "Building package..."
 	@uv build
 	@chmod 644 dist/*.whl
-	@echo "Deploying modalflow-main (with test DAGs)..."
-	@MODALFLOW_DAGS_DIR=tests/system/dags uv run modal deploy src/modalflow/modal_app.py
+	@echo "Pushing test DAGs to volume '$(DAG_VOLUME_NAME)'..."
+	@uv run modalflow sync --dags-path tests/system/dags --dags-volume $(DAG_VOLUME_NAME)
 	@echo "Setup complete. Run 'make system.test.e2e' to start tests."
 
-# Set up system tests with volume-based DAG loading
-system.setup.volume:
-	@echo "Setting up system test with volume-based DAGs..."
-	@echo "Building package..."
-	@uv build
-	@chmod 644 dist/*.whl
-	@echo "Deploying modalflow-main (volume mode, no baked DAGs)..."
-	@MODALFLOW_DAGS_VOLUME=test-dags-vol uv run modal deploy src/modalflow/modal_app.py
-	@echo "Uploading DAGs to volume..."
-	@uv run modalflow sync --dags-path tests/system/dags --dags-volume test-dags-vol
-	@echo "Setup complete. Run 'make system.test.e2e.volume' to start tests."
+# Set up system tests with volume-based DAG loading.
+# Identical to system.setup (volume-only flow); kept as a separate target so
+# 'make system.test.e2e.volume' has a matching setup entry point.
+system.setup.volume: system.setup
+	@echo "Volume setup complete. Run 'make system.test.e2e.volume' to start tests."
 
 # Run system tests using airflow standalone in Modal Sandbox
 system.test:

--- a/tests/system/environment_variables.env
+++ b/tests/system/environment_variables.env
@@ -1,2 +1,6 @@
 AIRFLOW__CORE__EXECUTOR=modalflow.executor.modal_executor.ModalExecutor
 AIRFLOW__CORE__LOAD_EXAMPLES=false
+# Modalflow environment + DAG source for the in-sandbox executor.
+# The executor mounts this Modal Volume into each per-task execution sandbox.
+MODALFLOW_ENV=main
+MODALFLOW_DAGS_VOLUME=test-dags-vol

--- a/tests/system/test_app.py
+++ b/tests/system/test_app.py
@@ -1,8 +1,15 @@
 """
 Modal app for running system tests with airflow standalone in a Sandbox.
 
-This creates a Sandbox that runs airflow standalone to test
-Airflow with the ModalExecutor configured.
+This creates a *control-plane* Sandbox that runs ``airflow standalone`` to test
+Airflow with the ModalExecutor configured.  The control-plane sandbox parses the
+DAGs locally (scheduler + dag-processor) from DAGs baked into ``airflow_test_image``.
+
+Per-task execution happens in separate, on-demand sandboxes created by the
+executor, which mount the test DAGs from a Modal Volume (``test-dags-vol``,
+pushed by ``make system.setup``).  There is no ``modal deploy`` step — the
+control-plane sandbox is told the DAG volume name via ``MODALFLOW_DAGS_VOLUME``
+(see ``environment_variables.env``).
 """
 import sys
 from pathlib import Path
@@ -34,6 +41,9 @@ airflow_test_image = (
     .run_commands(
         f'su -s /bin/bash airflow -c "pip install /tmp/{WHL_NAME}"'
     )
+    # Bake DAGs into the control-plane image so the scheduler/dag-processor can
+    # parse and schedule them.  Per-task execution sandboxes mount the same
+    # DAGs from the test-dags-vol Modal Volume instead (see module docstring).
     .add_local_dir(str(dags_dir), remote_path="/opt/airflow/dags", copy=True)
     .run_commands("chown -R airflow: /opt/airflow")
     .add_local_dir(str(test_dir), remote_path="/files/system")

--- a/tests/system/test_volume_dags.py
+++ b/tests/system/test_volume_dags.py
@@ -2,10 +2,11 @@
 E2E tests for volume-based DAG loading.
 
 These tests verify that DAGs served from a Modal Volume (rather than
-baked into the function image) work correctly end-to-end.
+baked into a function image) work correctly end-to-end.  Per-task execution
+sandboxes mount the DAGs from the test-dags-vol Modal Volume.
 
 Prerequisites:
-    make system.setup.volume   # deploy with volume mode + upload DAGs
+    make system.setup.volume   # build wheel + push DAGs to test-dags-vol volume
 """
 
 from test_app import create_test_sandbox


### PR DESCRIPTION
## Summary

Migrate the system-test infrastructure to the Sandbox-per-task model (Unit 3). Per-task execution now happens in independent Modal Sandboxes that mount DAGs from a Modal Volume; there is no longer a `modal deploy` step or baked-DAG (`MODALFLOW_DAGS_DIR`) mode for execution.

## Changes

- **Makefile**:
  - `system.setup` builds the wheel and pushes test DAGs to the `test-dags-vol` Modal Volume via `uv run modalflow sync` instead of `modal deploy`. The `MODALFLOW_DAGS_DIR` baked-DAG path is removed. Volume name is a `DAG_VOLUME_NAME` make var for consistency.
  - `system.setup.volume` now depends on `system.setup` (the flow is identical and volume-only), keeping `make system.test.e2e.volume` working.
  - `system.test.e2e`, `system.test.e2e.volume`, `system.teardown`, `unit.test`, `build` unchanged.
- **tests/system/environment_variables.env**: sets `MODALFLOW_ENV=main` and `MODALFLOW_DAGS_VOLUME=test-dags-vol` so the executor inside the control-plane sandbox resolves the DAG volume to mount into each per-task sandbox. These are exported by the `set -a && source ...env` in `start_airflow_and_wait_ready`.
- **tests/system/test_app.py**: docstring/comments clarify the control-plane sandbox (parses baked DAGs locally for scheduling, mounts `airflow-logs-main`) vs per-task execution sandboxes (mount `test-dags-vol`). DAGs remain baked into the control-plane image and the log volume stays mounted.
- **tests/system/test_volume_dags.py**: prerequisite docstring updated (no deploy).

## Validation

- `make -n system.setup` / `system.setup.volume` confirm the new `modalflow sync` flow and no `modal deploy`.
- All other targets dry-run cleanly.
- Full `make system.test.e2e` not run here (needs Modal credentials + the core executor migration). The 4 failing unit tests in `tests/unit/test_modal_executor.py` reference `state_dict`/`execute_modal_task` and belong to the core (Unit 1) migration — outside this unit's owned files and unaffected by these changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)