### PR TITLE
feat: run Airflow tasks as on-demand Modal Sandboxes

### DIFF
--- a/src/modalflow/executor/modal_executor.py
+++ b/src/modalflow/executor/modal_executor.py
@@ -1,16 +1,18 @@
 from __future__ import annotations
 
+import json
 import logging
 import os
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Dict, List, Optional, Sequence, Union
-from urllib.parse import urljoin
 
 import modal
 from airflow.configuration import conf
 from airflow.executors.base_executor import BaseExecutor
 from airflow.executors import workloads as executor_workloads
 from airflow.models.taskinstance import TaskInstanceKey
+
+from modalflow import modal_app
 
 if TYPE_CHECKING:
     from airflow.executors.workloads import All as ExecutorWorkload
@@ -26,7 +28,7 @@ CONCURRENCY_LIMIT = 100
 
 class ModalExecutor(BaseExecutor):
     """
-    An Airflow Executor that runs tasks as Modal Functions.
+    An Airflow Executor that runs each task as an independent Modal Sandbox.
     """
 
     is_local: bool = True
@@ -34,12 +36,14 @@ class ModalExecutor(BaseExecutor):
     def __init__(self):
         # Use the same concurrency limit as the Modal function
         super().__init__(parallelism=CONCURRENCY_LIMIT)
-        self.active_tasks: Dict[str, TaskInstanceKey] = {}
+        # Maps task_key_str -> handle dict:
+        #   {"key": TaskInstanceKey, "sandbox": Sandbox,
+        #    "process": ContainerProcess, "log_path": str | None}
+        self.active_tasks: Dict[str, Dict[str, Any]] = {}
         # These will be initialized in start()
-        self._modal_function = None
-        self._state_dict = None
-        self._tunnel_context = None  # Store the context manager
-        self._tunnel = None  # Store the tunnel object from __enter__()
+        self._app = None
+        self._image = None
+        self._volumes = None
         self._execution_api_url = None
 
     @property
@@ -52,36 +56,30 @@ class ModalExecutor(BaseExecutor):
 
     def start(self):
         """
-        Initialize the executor by looking up the deployed Modal function and state dict.
-        Also sets up networking (tunnel for local or production URL).
+        Initialize the executor by building the task image, resolving the
+        DAG + log volumes, and looking up (or creating) the Modal App that
+        owns the per-task sandboxes.
+
+        No deployed function or state dict is required — each task runs as
+        an independent Modal Sandbox created on demand by ``execute_async``.
         """
         self.log.info("Starting ModalExecutor")
 
-        app_name = f"modalflow-{ENV}"
-        dict_name = f"airflow-state-{ENV}"
-
-        # Look up the deployed Modal function
+        # Build the task image and resolve volumes via the builder module.
         try:
-            self._modal_function = modal.Function.from_name(
-                app_name, "execute_modal_task"
+            self._app = modal.App.lookup(modal_app.APP_NAME, create_if_missing=True)
+            self._image = modal_app.build_task_image()
+            self._volumes = modal_app.resolve_volumes()
+            self.log.info(
+                f"ModalExecutor ready: app={modal_app.APP_NAME}, "
+                f"volumes={list(self._volumes.keys())}"
             )
-            self.log.info(f"Connected to Modal function: {app_name}/execute_modal_task")
         except Exception as e:
-            self.log.error(
-                f"Failed to look up Modal function {app_name}/execute_modal_task: {e}"
-            )
-            raise
-
-        # Look up the state dictionary
-        try:
-            self._state_dict = modal.Dict.from_name(dict_name)
-            self.log.info(f"Connected to Modal Dict: {dict_name}")
-        except Exception as e:
-            self.log.error(f"Failed to connect to Modal Dict {dict_name}: {e}")
+            self.log.error(f"Failed to initialize Modal resources: {e}")
             raise
 
         # Set up execution API URL.
-        # Priority: env var > Airflow config > modal.forward() tunnel > error
+        # Priority: env var > Airflow config > error
         self._execution_api_url = self._resolve_execution_api_url()
         self.log.info(f"Execution API URL: {self._execution_api_url}")
 
@@ -93,47 +91,69 @@ class ModalExecutor(BaseExecutor):
         executor_config: Optional[Any] = None,
     ) -> None:
         """
-        Trigger a task execution on Modal.
+        Trigger a task execution by creating a Modal Sandbox.
 
         Handles two formats:
         - New-style: command is a list containing an ExecuteTask workload object.
-        - Old-style: command is a list of strings (CLI command).
+          The sandbox runs ``python -m airflow.sdk.execution_time.execute_workload``.
+        - Old-style: command is a list of strings (CLI command), run directly.
         """
         task_key_str = self._get_key_str(key)
-
-        if len(command) == 1 and isinstance(command[0], executor_workloads.ExecuteTask):
-            # New-style: serialize the workload to JSON
-            workload = command[0]
-            serialized_workload = workload.model_dump_json()
-            payload = {
-                "task_key": task_key_str,
-                "workload_json": serialized_workload,
-                "env": self._get_task_env(key, executor_config),
-            }
-        elif all(isinstance(c, str) for c in command):
-            # Old-style: pass the CLI command for direct execution
-            payload = {
-                "task_key": task_key_str,
-                "command": command,
-                "env": self._get_task_env(key, executor_config),
-            }
-        else:
-            raise RuntimeError(
-                f"ModalExecutor doesn't know how to handle command of type: {type(command)}"
-            )
-
-        self.log.info(f"Spawning Modal task for {task_key_str}")
 
         if self._execution_api_url is None:
             raise RuntimeError(
                 "Execution API URL not configured. Ensure start() was called successfully."
             )
 
+        log_path = None
+
+        if len(command) == 1 and isinstance(command[0], executor_workloads.ExecuteTask):
+            # New-style: serialize the workload to JSON and run via the SDK.
+            workload = command[0]
+            workload_json = workload.model_dump_json()
+            try:
+                log_path = json.loads(workload_json).get("log_path")
+            except Exception:
+                log_path = None
+            sandbox_command = [
+                "python",
+                "-m",
+                "airflow.sdk.execution_time.execute_workload",
+                "--json-string",
+                workload_json,
+            ]
+        elif all(isinstance(c, str) for c in command):
+            # Old-style: run the CLI command directly.
+            sandbox_command = list(command)
+        else:
+            raise RuntimeError(
+                f"ModalExecutor doesn't know how to handle command of type: {type(command)}"
+            )
+
+        self.log.info(f"Creating Modal sandbox for {task_key_str}")
+
+        task_env = self._get_task_env(key, executor_config)
+
         try:
-            self._modal_function.spawn(payload)
-            self.active_tasks[task_key_str] = key
+            # Create an idle (sleep infinity) sandbox, then run the task as
+            # an exec'd process inside it.  This keeps the sandbox alive after
+            # the task exits so we can read the structured log file before
+            # terminating it.
+            sb = modal_app.create_task_sandbox(
+                app=self._app,
+                image=self._image,
+                volumes=self._volumes,
+                env=task_env,
+            )
+            proc = sb.exec(*sandbox_command, env=task_env)
+            self.active_tasks[task_key_str] = {
+                "key": key,
+                "sandbox": sb,
+                "process": proc,
+                "log_path": log_path,
+            }
         except Exception as e:
-            self.log.error(f"Failed to spawn Modal task: {e}")
+            self.log.error(f"Failed to create Modal sandbox: {e}")
             self.fail(key)
 
     def _process_workloads(self, workloads: Sequence) -> None:
@@ -188,87 +208,109 @@ class ModalExecutor(BaseExecutor):
 
     def sync(self) -> None:
         """
-        Check the status of running tasks.
+        Poll each tracked sandbox for completion (non-blocking).
+
+        For each task whose sandbox process has finished, read the
+        structured log file out of the sandbox (before terminating it),
+        write it to the local log folder, report success/failure based on
+        the return code, terminate the sandbox, and stop tracking it.
         """
         if not self.active_tasks:
             return
 
-        # Poll the state dictionary
-        # TODO: batch this or use a more efficient lookup
-
         completed_keys = []
 
-        for task_key_str, key in self.active_tasks.items():
-            # Check if this key exists in the remote dict
-            # We use .get() to avoid errors if key is missing
+        for task_key_str, handle in self.active_tasks.items():
+            key = handle["key"]
+            proc = handle["process"]
+            sb = handle["sandbox"]
+            log_path = handle.get("log_path")
+
+            # poll() returns None while running, else the exit code.
             try:
-                task_state = self._state_dict.get(task_key_str)
+                return_code = proc.poll()
             except Exception as e:
-                self.log.warning(f"Error reading state for {task_key_str}: {e}")
+                self.log.warning(f"Error polling sandbox for {task_key_str}: {e}")
                 continue
 
-            if not task_state:
-                # Task not yet registered by worker, or lost
-                # TODO: implement a timeout logic here
+            if return_code is None:
+                # Still running.
                 continue
 
-            status = task_state.get("status")
+            # Read the structured log file out of the sandbox BEFORE
+            # terminating it, so logs are available locally.
+            log_content = self._read_sandbox_log(sb, log_path)
+            if log_content:
+                self._write_task_log(log_content, key)
 
-            if status == "SUCCESS":
-                self._write_task_log(task_state, key)
+            if return_code == 0:
                 self.success(key)
-                completed_keys.append(task_key_str)
                 self.log.info(f"Task {task_key_str} succeeded")
-
-            elif status == "FAILED":
-                self._write_task_log(task_state, key)
+            else:
                 self.fail(key)
-                completed_keys.append(task_key_str)
-                error_msg = task_state.get("error", "Unknown error")
-                self.log.error(f"Task {task_key_str} failed: {error_msg}")
-                if task_state.get("stderr"):
-                    self.log.error(f"Task {task_key_str} stderr: {task_state['stderr']}")
-                if task_state.get("stdout"):
-                    self.log.info(f"Task {task_key_str} stdout: {task_state['stdout']}")
+                self.log.error(
+                    f"Task {task_key_str} failed (return code {return_code})"
+                )
 
-        # Cleanup local state
+            # Terminate the sandbox to release resources.
+            try:
+                sb.terminate()
+            except Exception as e:
+                self.log.warning(f"Failed to terminate sandbox for {task_key_str}: {e}")
+
+            completed_keys.append(task_key_str)
+
         for k in completed_keys:
             del self.active_tasks[k]
-            # Cleanup remote state
-            try:
-                self._state_dict.pop(k)
-            except Exception as e:
-                self.log.warning(f"Failed to cleanup remote state for {k}: {e}") 
+
+    def _read_sandbox_log(self, sandbox, log_path: Optional[str]) -> str:
+        """Read the structured log file from a (still-running) sandbox.
+
+        Returns the file contents, or an empty string if unavailable.
+        """
+        if not log_path:
+            return ""
+
+        log_file = os.path.join("/opt/airflow/logs", log_path)
+        try:
+            proc = sandbox.exec("cat", log_file)
+            content = proc.stdout.read()
+            proc.wait()
+            if proc.returncode != 0:
+                return ""
+            return content or ""
+        except Exception as e:
+            self.log.warning(f"Failed to read log file {log_file} from sandbox: {e}")
+            return ""
 
     def get_task_log(self, ti: TaskInstance, try_number: int) -> tuple[list[str], list[str]]:
-        """Return partial logs from state_dict for running tasks.
+        """Return partial logs from the live sandbox for running tasks.
 
-        Called by FileTaskHandler when ti.state == RUNNING.  Once the task
-        completes, full logs are read from the local filesystem (written by
-        ``_write_task_log`` during ``sync()``).
+        Called by FileTaskHandler when ti.state == RUNNING.  Reads the
+        in-progress structured log file directly from the running sandbox.
+        Once the task completes, full logs are read from the local
+        filesystem (written by ``_write_task_log`` during ``sync()``).
         """
         task_key_str = self._get_key_str(ti.key)
-        try:
-            task_state = self._state_dict.get(task_key_str)
-        except Exception:
+        handle = self.active_tasks.get(task_key_str)
+        if not handle:
             return [], []
-        if task_state and task_state.get("stdout"):
+
+        content = self._read_sandbox_log(handle["sandbox"], handle.get("log_path"))
+        if content:
             return (
                 [f"Modal task output for {task_key_str}"],
-                [task_state["stdout"]],
+                [content],
             )
         return [f"Task {task_key_str} running on Modal"], ["Waiting for output..."]
 
-    def _write_task_log(self, task_state: dict, key: TaskInstanceKey) -> None:
-        """Write task log content from state_dict to the local base_log_folder.
+    def _write_task_log(self, content: str, key: TaskInstanceKey) -> None:
+        """Write task log content to the local base_log_folder.
 
         This makes ``FileTaskHandler._read_from_local()`` work for completed
         tasks even when the Airflow scheduler doesn't share a Modal Volume
-        with the Modal Functions (e.g. local / production deployments).
+        with the task sandboxes (e.g. local / production deployments).
         """
-        # Prefer structured log content from the Airflow SDK supervisor,
-        # fall back to raw stdout captured from the subprocess.
-        content = task_state.get("log_content") or task_state.get("stdout") or ""
         if not content:
             return
 
@@ -300,21 +342,21 @@ class ModalExecutor(BaseExecutor):
     def end(self) -> None:
         """
         Terminate the executor and cleanup resources.
+
+        Terminates any sandboxes that are still tracked (e.g. on shutdown
+        while tasks are mid-flight).
         """
         self.log.info("Shutting down ModalExecutor")
         self.heartbeat_interval = 0
 
-        # Cleanup tunnel if it exists
-        if self._tunnel_context is not None:
+        for task_key_str, handle in list(self.active_tasks.items()):
             try:
-                # Exit the context manager
-                self._tunnel_context.__exit__(None, None, None)
-                self.log.info("Closed tunnel")
+                handle["sandbox"].terminate()
             except Exception as e:
-                self.log.warning(f"Error closing tunnel: {e}")
-            finally:
-                self._tunnel_context = None
-                self._tunnel = None
+                self.log.warning(
+                    f"Failed to terminate sandbox for {task_key_str}: {e}"
+                )
+        self.active_tasks.clear()
 
     def terminate(self) -> None:
         """
@@ -342,7 +384,6 @@ class ModalExecutor(BaseExecutor):
         Priority:
         1. Environment variable AIRFLOW__CORE__EXECUTION_API_SERVER_URL
         2. Airflow config: core.execution_api_server_url
-        3. modal.forward() tunnel (only works inside Modal Functions)
 
         The URL must end with ``/execution/`` because the Airflow task SDK
         uses relative paths (e.g. ``task-instances/{id}/run``).  If the
@@ -371,20 +412,11 @@ class ModalExecutor(BaseExecutor):
         except Exception as e:
             self.log.warning(f"Error reading execution_api_server_url from config: {e}")
 
-        # 3. Try modal.forward() tunnel (works inside Modal Functions only)
-        self.log.info(
-            "No execution API URL configured, attempting modal.forward() tunnel"
+        raise RuntimeError(
+            "Execution API URL not configured. "
+            "Set AIRFLOW__CORE__EXECUTION_API_SERVER_URL or the "
+            "core.execution_api_server_url Airflow config."
         )
-        try:
-            self._tunnel_context = modal.forward(8080)
-            self._tunnel = self._tunnel_context.__enter__()
-            tunnel_url = self._tunnel.url
-            return self._ensure_execution_prefix(tunnel_url)
-        except Exception as e:
-            raise RuntimeError(
-                f"Execution API URL not configured and tunnel creation failed: {e}. "
-                "Set AIRFLOW__CORE__EXECUTION_API_SERVER_URL or run inside a Modal container."
-            ) from e
 
     def _validate_api_url(self, url: str) -> None:
         """

--- a/src/modalflow/modal_app.py
+++ b/src/modalflow/modal_app.py
@@ -1,216 +1,125 @@
+"""Builder helpers for running Airflow tasks as Modal Sandboxes.
+
+This module no longer defines a long-lived deployed function or a
+``modal.Dict`` state store.  Instead it exposes helpers that the
+``ModalExecutor`` imports to build the task image, resolve volumes, and
+create a fresh ``modal.Sandbox`` for each Airflow task on demand.
+
+DAG source is **volume-only**: DAGs live on a Modal Volume (named via
+``MODALFLOW_DAGS_VOLUME``) and are mounted into each task sandbox at
+``/opt/airflow/dags``.
+"""
+
 import os
-import subprocess
-from pathlib import Path
+from typing import Optional
 
 import modal
 
-# Allow overriding the environment name via env var
+# Allow overriding the environment name via env var.
 ENV = os.environ.get("MODALFLOW_ENV", "main")
 
-# Maximum number of concurrent Modal function calls
-# This should match the executor's parallelism setting
-CONCURRENCY_LIMIT = 100
+# Name of the Modal App that owns the task sandboxes.
+APP_NAME = f"modalflow-{ENV}"
 
-# DAG source configuration (set by CLI at deploy time)
-DAGS_DIR = os.environ.get("MODALFLOW_DAGS_DIR", None)            # local mode
-DAGS_VOLUME_NAME = os.environ.get("MODALFLOW_DAGS_VOLUME", None)  # volume mode
-DAGS_BUCKET = os.environ.get("MODALFLOW_DAGS_BUCKET", None)       # cloud-bucket mode
-DAGS_BUCKET_SECRET = os.environ.get("MODALFLOW_DAGS_BUCKET_SECRET", None)
-
-# Airflow version to install (configurable via CLI --airflow-version flag)
+# Airflow version to install (configurable via CLI --airflow-version flag).
 AIRFLOW_VERSION = os.environ.get("MODALFLOW_AIRFLOW_VERSION", "3.1.5")
 
-# Define the base image
-# We use the official Airflow image to ensure compatibility.
-# Upgrade from 3.0.6 to 3.1.x+ (3.0.6 lacks queue_workload support).
-airflow_image = (
-    modal.Image.from_registry("apache/airflow:3.0.6-python3.10")
-    .run_commands(
-        f'su -s /bin/bash airflow -c "pip install apache-airflow=={AIRFLOW_VERSION}"'
-    )
-    .pip_install(
-        "modal",
-        "rich",
-        "click",
-        "pyyaml",
-        "psycopg2-binary",
-    )
-)
+# DAG source: volume-only.  The volume is mounted at /opt/airflow/dags.
+DAGS_VOLUME_NAME = os.environ.get("MODALFLOW_DAGS_VOLUME", None)
 
-# Include DAG files in the image only for local mode.
-# Volume and cloud-bucket modes mount DAGs at runtime instead.
-if DAGS_DIR:
-    airflow_image = airflow_image.add_local_dir(
-        DAGS_DIR, remote_path="/opt/airflow/dags", copy=True
-    )
-
-# Create the Modal App
-app = modal.App(f"modalflow-{ENV}", image=airflow_image)
-
-# Define the volume for logs
-# We use a dedicated volume for logs so they persist and can be read back
-log_volume = modal.Volume.from_name(f"airflow-logs-{ENV}", create_if_missing=True)
-
-# Define the dict for coordination (hot cache)
-# Maps task_key -> {status, return_code, last_updated}
-state_dict = modal.Dict.from_name(f"airflow-state-{ENV}", create_if_missing=True)
-
-# Build volumes dict dynamically based on DAG source.
-# Both modal.Volume and modal.CloudBucketMount are accepted in the volumes dict.
-function_volumes = {"/opt/airflow/logs": log_volume}
-
-if DAGS_VOLUME_NAME:
-    dags_volume = modal.Volume.from_name(DAGS_VOLUME_NAME, create_if_missing=True)
-    function_volumes["/opt/airflow/dags"] = dags_volume
-
-if DAGS_BUCKET:
-    # Parse S3 URI: s3://bucket-name/optional/prefix
-    bucket_path = DAGS_BUCKET.removeprefix("s3://")
-    parts = bucket_path.split("/", 1)
-    bucket_name = parts[0]
-    key_prefix = parts[1] if len(parts) > 1 else ""
-
-    mount_kwargs = {"bucket_name": bucket_name}
-    if key_prefix:
-        mount_kwargs["key_prefix"] = key_prefix
-    if DAGS_BUCKET_SECRET:
-        mount_kwargs["secret"] = modal.Secret.from_name(DAGS_BUCKET_SECRET)
-
-    function_volumes["/opt/airflow/dags"] = modal.CloudBucketMount(**mount_kwargs)
-
-# Pass DAG source env vars to the function container so that conditional
-# volume/mount definitions evaluate identically on the remote side.
-function_env = {}
-if DAGS_VOLUME_NAME:
-    function_env["MODALFLOW_DAGS_VOLUME"] = DAGS_VOLUME_NAME
-if DAGS_BUCKET:
-    function_env["MODALFLOW_DAGS_BUCKET"] = DAGS_BUCKET
-if DAGS_BUCKET_SECRET:
-    function_env["MODALFLOW_DAGS_BUCKET_SECRET"] = DAGS_BUCKET_SECRET
+# Default sandbox timeout (seconds).
+DEFAULT_TASK_TIMEOUT = int(os.environ.get("MODALFLOW_TASK_TIMEOUT", "3600"))
 
 
-@app.function(
-    volumes=function_volumes,
-    env=function_env or None,
-    timeout=3600,  # Default 1 hour timeout
-    max_containers=CONCURRENCY_LIMIT,
-)
-def execute_modal_task(payload: dict):
+def build_task_image() -> modal.Image:
+    """Build the Modal Image used to run Airflow tasks.
+
+    Mirrors the system-test image build: start from the official Airflow
+    image, upgrade Airflow via pip (run as the ``airflow`` user, uid 50000),
+    then install modalflow's runtime deps.  DAGs are NOT baked into the
+    image — they are mounted from a Volume at runtime.
     """
-    Executes an Airflow task either via the SDK workload API or a CLI command.
+    return (
+        modal.Image.from_registry("apache/airflow:3.0.6-python3.10")
+        # Clear the Airflow image's ENTRYPOINT so Modal's sandbox init
+        # process doesn't exit immediately (which would terminate the
+        # sandbox before our task command runs).
+        .dockerfile_commands(["ENTRYPOINT []", "CMD []"])
+        # Upgrade Airflow (3.0.6 uses old-style queue_command tuples;
+        # 3.1.x uses queue_workload with ExecuteTask objects).  pip must
+        # run as the airflow user, not root.
+        .run_commands(
+            f'su -s /bin/bash airflow -c "pip install apache-airflow=={AIRFLOW_VERSION}"'
+        )
+        .pip_install(
+            "modal",
+            "rich",
+            "click",
+            "pyyaml",
+            "psycopg2-binary",
+        )
+    )
 
-    Payload structure (new-style):
-    {
-        "task_key": "dag_id:task_id:run_id:try_number",
-        "workload_json": "<serialized ExecuteTask workload JSON>",
-        "env": {"AIRFLOW__CORE__...", ...}
-    }
 
-    Payload structure (old-style):
-    {
-        "task_key": "dag_id:task_id:run_id:try_number",
-        "command": ["airflow", "tasks", "run", dag_id, task_id, run_id, ...],
-        "env": {"AIRFLOW__CORE__...", ...}
-    }
+def resolve_volumes(dags_volume_name: Optional[str] = None) -> dict:
+    """Resolve the volumes to mount into each task sandbox.
+
+    Always mounts the log volume ``airflow-logs-{ENV}`` at
+    ``/opt/airflow/logs``.  Mounts the DAG volume at ``/opt/airflow/dags``
+    when a volume name is provided (defaults to ``MODALFLOW_DAGS_VOLUME``).
+
+    Returns:
+        Mapping of mount path -> ``modal.Volume`` suitable for
+        ``modal.Sandbox.create(volumes=...)``.
     """
-    import json
-    import os
+    name = dags_volume_name or DAGS_VOLUME_NAME
 
-    task_key = payload.get("task_key")
-    workload_json = payload.get("workload_json")
-    cli_command = payload.get("command")
-    env_vars = payload.get("env", {})
+    log_volume = modal.Volume.from_name(
+        f"airflow-logs-{ENV}", create_if_missing=True
+    )
+    volumes = {"/opt/airflow/logs": log_volume}
 
-    # Extract log_path from workload so we can read the structured log file
-    # written by the Airflow SDK supervisor after execution.
-    log_path = None
-    if workload_json:
-        try:
-            workload_data = json.loads(workload_json)
-            log_path = workload_data.get("log_path")
-        except Exception:
-            pass
+    if name:
+        dags_volume = modal.Volume.from_name(name, create_if_missing=True)
+        volumes["/opt/airflow/dags"] = dags_volume
 
-    print(f"Starting execution for {task_key}")
+    return volumes
 
-    if workload_json:
-        # New-style: use the Airflow SDK execute_workload module
-        command = [
-            "python",
-            "-m",
-            "airflow.sdk.execution_time.execute_workload",
-            "--json-string",
-            workload_json,
-        ]
-        print(
-            "Using SDK workload path: python -m airflow.sdk.execution_time.execute_workload --json-string <workload>"
-        )
-    elif cli_command:
-        # Old-style: run the CLI command directly
-        command = cli_command
-        print(f"Using CLI path: {' '.join(command)}")
-    else:
-        raise ValueError(
-            f"Payload must contain 'workload_json' or 'command', got keys: {list(payload.keys())}"
-        )
 
-    # Set environment variables
-    # Merge with existing env, but executor-provided vars take precedence
-    run_env = os.environ.copy()
-    run_env.update(env_vars)
+def create_task_sandbox(
+    app: modal.App,
+    image: modal.Image,
+    volumes: dict,
+    env: Optional[dict] = None,
+    timeout: int = DEFAULT_TASK_TIMEOUT,
+) -> modal.Sandbox:
+    """Create an idle Modal Sandbox for running a single Airflow task.
 
-    # Update state to RUNNING right before execution
-    state_dict[task_key] = {
-        "status": "RUNNING",
-        "return_code": None,
-        "ts": 0,  # Timestamp placeholder
-    }
+    The sandbox is created with a ``sleep infinity`` entrypoint so it stays
+    alive after the task command (run via ``sandbox.exec(...)``) finishes.
+    This lets the executor read the structured log file out of the sandbox
+    *after* the task process exits but *before* the sandbox is terminated.
+    (A sandbox whose entrypoint was the task command itself would finish and
+    become unreachable the moment the task exits — see the proven
+    ``sleep infinity`` + ``exec`` pattern in ``tests/system/test_app.py``.)
 
-    try:
-        # Run the command
-        # We use subprocess.run to block until completion
-        result = subprocess.run(
-            command,
-            env=run_env,
-            capture_output=True,
-            text=True,
-            check=False,
-        )
+    Args:
+        app: The Modal App the sandbox belongs to.
+        image: The task image (see :func:`build_task_image`).
+        volumes: Volume mounts (see :func:`resolve_volumes`).
+        env: Per-task environment variables (e.g. the execution API URL).
+        timeout: Sandbox timeout in seconds.
 
-        # Log output to Modal's centralized logging
-        print(f"Return code: {result.returncode}")
-        print(f"STDOUT:\n{result.stdout}")
-        print(f"STDERR:\n{result.stderr}")
-
-        status = "SUCCESS" if result.returncode == 0 else "FAILED"
-
-        # Try to read the structured log file written by the Airflow SDK
-        # supervisor.  This contains properly formatted task logs.
-        log_content = ""
-        if log_path:
-            log_file = os.path.join("/opt/airflow/logs", log_path)
-            try:
-                with open(log_file) as f:
-                    log_content = f.read()
-                print(f"Read {len(log_content)} bytes from {log_file}")
-            except FileNotFoundError:
-                print(f"Log file not found at {log_file}, will use stdout")
-            except Exception as e:
-                print(f"Failed to read log file {log_file}: {e}")
-
-        state_dict[task_key] = {
-            "status": status,
-            "return_code": result.returncode,
-            "stdout": result.stdout,
-            "stderr": result.stderr[-2000:],
-            "log_content": log_content,
-        }
-
-    except Exception as e:
-        print(f"Execution failed: {e}")
-        state_dict[task_key] = {
-            "status": "FAILED",
-            "return_code": -1,
-            "error": str(e),
-        }
-        raise
+    Returns:
+        The created (running) ``modal.Sandbox``.
+    """
+    return modal.Sandbox.create(
+        "sleep",
+        "infinity",
+        app=app,
+        image=image,
+        secrets=[modal.Secret.from_name("modal")],
+        volumes=volumes,
+        env=env or {},
+        timeout=timeout,
+    )

--- a/tests/unit/test_modal_executor.py
+++ b/tests/unit/test_modal_executor.py
@@ -9,111 +9,206 @@ sys.modules["airflow"] = mock_airflow
 sys.modules["airflow.configuration"] = mock_airflow.configuration
 sys.modules["airflow.executors"] = mock_airflow.executors
 sys.modules["airflow.executors.base_executor"] = mock_airflow.executors.base_executor
+sys.modules["airflow.executors.workloads"] = mock_airflow.executors.workloads
 sys.modules["airflow.models"] = mock_airflow.models
 sys.modules["airflow.models.taskinstance"] = mock_airflow.models.taskinstance
 sys.modules["airflow.utils"] = mock_airflow.utils
 sys.modules["airflow.utils.state"] = mock_airflow.utils.state
 
+
 # Mock BaseExecutor class
 class MockBaseExecutor:
     def __init__(self, parallelism=16):
         self.parallelism = parallelism
-    def fail(self, key): pass
-    def success(self, key): pass
-    def validate_command(self, cmd): pass
+
+    def fail(self, key):
+        pass
+
+    def success(self, key):
+        pass
+
+    def validate_command(self, cmd):
+        pass
+
 
 mock_airflow.executors.base_executor.BaseExecutor = MockBaseExecutor
 
+
 # Mock TaskInstanceKey class
 class MockTaskInstanceKey:
-    def __init__(self, dag_id, task_id, run_id, try_number):
+    def __init__(self, dag_id, task_id, run_id, try_number, map_index=-1):
         self.dag_id = dag_id
         self.task_id = task_id
         self.run_id = run_id
         self.try_number = try_number
+        self.map_index = map_index
+
 
 mock_airflow.models.taskinstance.TaskInstanceKey = MockTaskInstanceKey
+
+# Use a sentinel class for ExecuteTask so isinstance() checks in the
+# executor only match real workload objects (our CLI-list path uses
+# plain strings).
+class _FakeExecuteTask:
+    pass
+
+
+mock_airflow.executors.workloads.ExecuteTask = _FakeExecuteTask
 
 # --- Import Code Under Test ---
 # We must do this AFTER mocking
 from modalflow.executor.modal_executor import ModalExecutor
 
-class TestModalExecutor(unittest.TestCase):
-    def setUp(self):
-        self.executor = ModalExecutor()
-        self.executor.active_tasks = {}
 
-    @mock.patch("modalflow.executor.modal_executor.execute_modal_task")
-    def test_execute_async(self, mock_task):
+def _make_executor():
+    executor = ModalExecutor()
+    executor.active_tasks = {}
+    executor.log = mock.Mock(name="log")
+    # start() is not called in unit tests; set the bits execute_async needs.
+    executor._execution_api_url = "http://localhost:8080/execution/"
+    executor._app = mock.Mock(name="app")
+    executor._image = mock.Mock(name="image")
+    executor._volumes = {"/opt/airflow/logs": mock.Mock(), "/opt/airflow/dags": mock.Mock()}
+    return executor
+
+
+class TestExecuteAsync(unittest.TestCase):
+    @mock.patch("modalflow.modal_app.modal.Sandbox.create")
+    @mock.patch("modalflow.modal_app.modal.Secret.from_name")
+    def test_execute_async(self, mock_secret, mock_create):
+        executor = _make_executor()
+        mock_sb = mock.Mock(name="sandbox")
+        mock_proc = mock.Mock(name="process")
+        mock_sb.exec.return_value = mock_proc
+        mock_create.return_value = mock_sb
+
         key = MockTaskInstanceKey("dag", "task", "run_id", 1)
         command = ["airflow", "tasks", "run", "dag", "task", "run_id", "--local"]
-        
-        self.executor.execute_async(key, command)
-        
-        # Verify spawn called
-        mock_task.spawn.assert_called_once()
-        call_args = mock_task.spawn.call_args[0][0]
-        self.assertEqual(call_args["task_key"], "dag:task:run_id:1")
-        self.assertEqual(call_args["command"], command)
-        
-        # Verify added to active tasks
-        self.assertIn("dag:task:run_id:1", self.executor.active_tasks)
 
-    @mock.patch("modalflow.executor.modal_executor.state_dict")
-    def test_sync_success(self, mock_state_dict):
+        executor.execute_async(key, command)
+
+        # A sandbox was created and the command was exec'd inside it.
+        mock_create.assert_called_once()
+        mock_sb.exec.assert_called_once()
+        exec_args = list(mock_sb.exec.call_args[0])
+        self.assertEqual(exec_args, command)
+
+        # Task tracked under the right key with a handle dict.
+        self.assertIn("dag:task:run_id:1", executor.active_tasks)
+        handle = executor.active_tasks["dag:task:run_id:1"]
+        self.assertIs(handle["sandbox"], mock_sb)
+        self.assertIs(handle["process"], mock_proc)
+        self.assertIs(handle["key"], key)
+
+    @mock.patch("modalflow.modal_app.modal.Sandbox.create")
+    @mock.patch("modalflow.modal_app.modal.Secret.from_name")
+    def test_execute_async_workload(self, mock_secret, mock_create):
+        executor = _make_executor()
+        mock_sb = mock.Mock(name="sandbox")
+        mock_proc = mock.Mock(name="process")
+        mock_sb.exec.return_value = mock_proc
+        mock_create.return_value = mock_sb
+
+        key = MockTaskInstanceKey("dag", "task", "run_id", 1)
+        workload = _FakeExecuteTask()
+        workload.model_dump_json = mock.Mock(
+            return_value='{"log_path": "dag_id=dag/run_id=run_id/task_id=task/attempt=1.log"}'
+        )
+
+        executor.execute_async(key, [workload])
+
+        mock_sb.exec.assert_called_once()
+        exec_args = list(mock_sb.exec.call_args[0])
+        self.assertEqual(
+            exec_args,
+            [
+                "python",
+                "-m",
+                "airflow.sdk.execution_time.execute_workload",
+                "--json-string",
+                workload.model_dump_json.return_value,
+            ],
+        )
+        handle = executor.active_tasks["dag:task:run_id:1"]
+        self.assertEqual(
+            handle["log_path"],
+            "dag_id=dag/run_id=run_id/task_id=task/attempt=1.log",
+        )
+
+
+class TestSync(unittest.TestCase):
+    def _track_task(self, executor, return_code, log_path=None):
         key = MockTaskInstanceKey("dag", "task", "run_id", 1)
         task_key_str = "dag:task:run_id:1"
-        self.executor.active_tasks[task_key_str] = key
-        
-        # Mock successful state
-        mock_state_dict.get.return_value = {"status": "SUCCESS"}
-        
-        # Mock airflow methods
-        self.executor.success = mock.Mock()
-        self.executor.fail = mock.Mock()
-        
-        self.executor.sync()
-        
-        self.executor.success.assert_called_once_with(key)
-        self.executor.fail.assert_not_called()
-        self.assertNotIn(task_key_str, self.executor.active_tasks)
+        proc = mock.Mock(name="process")
+        proc.poll.return_value = return_code
+        sb = mock.Mock(name="sandbox")
+        sb.poll.return_value = return_code
+        executor.active_tasks[task_key_str] = {
+            "key": key,
+            "sandbox": sb,
+            "process": proc,
+            "log_path": log_path,
+        }
+        return key, task_key_str, sb, proc
 
-    @mock.patch("modalflow.executor.modal_executor.state_dict")
-    def test_sync_failed(self, mock_state_dict):
-        key = MockTaskInstanceKey("dag", "task", "run_id", 1)
-        task_key_str = "dag:task:run_id:1"
-        self.executor.active_tasks[task_key_str] = key
-        
-        # Mock failed state
-        mock_state_dict.get.return_value = {"status": "FAILED", "error": "Something exploded"}
-        
-        # Mock airflow methods
-        self.executor.success = mock.Mock()
-        self.executor.fail = mock.Mock()
-        
-        self.executor.sync()
-        
-        self.executor.fail.assert_called_once_with(key)
-        self.executor.success.assert_not_called()
-        self.assertNotIn(task_key_str, self.executor.active_tasks)
+    def test_sync_success(self):
+        executor = _make_executor()
+        executor.success = mock.Mock()
+        executor.fail = mock.Mock()
+        key, task_key_str, sb, proc = self._track_task(executor, return_code=0)
 
-    @mock.patch("modalflow.executor.modal_executor.state_dict")
-    def test_sync_pending(self, mock_state_dict):
-        key = MockTaskInstanceKey("dag", "task", "run_id", 1)
-        task_key_str = "dag:task:run_id:1"
-        self.executor.active_tasks[task_key_str] = key
-        
-        # Mock pending state (or missing state)
-        mock_state_dict.get.return_value = {"status": "RUNNING"}
-        
-        self.executor.success = mock.Mock()
-        self.executor.fail = mock.Mock()
-        
-        self.executor.sync()
-        
-        self.executor.success.assert_not_called()
-        self.executor.fail.assert_not_called()
-        self.assertIn(task_key_str, self.executor.active_tasks)
+        executor.sync()
+
+        executor.success.assert_called_once_with(key)
+        executor.fail.assert_not_called()
+        sb.terminate.assert_called_once()
+        self.assertNotIn(task_key_str, executor.active_tasks)
+
+    def test_sync_failed(self):
+        executor = _make_executor()
+        executor.success = mock.Mock()
+        executor.fail = mock.Mock()
+        key, task_key_str, sb, proc = self._track_task(executor, return_code=1)
+
+        executor.sync()
+
+        executor.fail.assert_called_once_with(key)
+        executor.success.assert_not_called()
+        sb.terminate.assert_called_once()
+        self.assertNotIn(task_key_str, executor.active_tasks)
+
+    def test_sync_pending(self):
+        executor = _make_executor()
+        executor.success = mock.Mock()
+        executor.fail = mock.Mock()
+        key, task_key_str, sb, proc = self._track_task(executor, return_code=None)
+
+        executor.sync()
+
+        executor.success.assert_not_called()
+        executor.fail.assert_not_called()
+        sb.terminate.assert_not_called()
+        self.assertIn(task_key_str, executor.active_tasks)
+
+    def test_sync_success_writes_log(self):
+        executor = _make_executor()
+        executor.success = mock.Mock()
+        executor.fail = mock.Mock()
+        executor._write_task_log = mock.Mock()
+        key, task_key_str, sb, proc = self._track_task(
+            executor, return_code=0, log_path="dag_id=dag/run_id=run_id/task_id=task/attempt=1.log"
+        )
+        # Sandbox.exec("cat", ...) returns a process whose stdout reads log content.
+        cat_proc = mock.Mock()
+        cat_proc.stdout.read.return_value = "structured log content"
+        cat_proc.returncode = 0
+        sb.exec.return_value = cat_proc
+
+        executor.sync()
+
+        executor._write_task_log.assert_called_once_with("structured log content", key)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/uv.lock
+++ b/uv.lock
@@ -1737,7 +1737,7 @@ wheels = [
 
 [[package]]
 name = "modalflow"
-version = "0.2.4"
+version = "0.3.1"
 source = { editable = "." }
 dependencies = [
     { name = "apache-airflow" },


### PR DESCRIPTION
## Summary

Migrates the executor backend from a long-lived **deployed Modal Function** + `modal.Dict` state store to **per-task Modal Sandboxes** created on demand. Removes the deploy-step requirement; DAGs are volume-only.

## Changes

### `src/modalflow/modal_app.py` — now a builder module
- `build_task_image()` — base Airflow image, pip-upgrade as the `airflow` user, install modalflow deps. No DAGs baked in.
- `resolve_volumes()` — mounts `airflow-logs-{ENV}` at `/opt/airflow/logs` and the `MODALFLOW_DAGS_VOLUME` volume at `/opt/airflow/dags`.
- `create_task_sandbox()` — creates an idle (`sleep infinity`) sandbox with the image, volumes, `modal` secret, env, and timeout.
- Removed: `@app.function execute_modal_task`, `modal.Dict` state store, `max_containers`, local/cloud-bucket DAG mounting.

### `src/modalflow/executor/modal_executor.py`
- `start()` builds the task image + resolves volumes (no `Function.from_name`/`Dict.from_name`). Keeps execution-API-URL resolution.
- `execute_async()` creates a sandbox and `exec`s the workload/CLI command inside it (sandbox stays alive via `sleep infinity` so logs can be read back after the task exits). Tracks `{key, sandbox, process, log_path}` in `active_tasks`.
- `sync()` is non-blocking: polls each exec process; on completion reads the structured log file out of the still-alive sandbox, writes it locally via `_write_task_log`, reports success/fail by return code, then terminates the sandbox.
- `get_task_log()` reads partial logs from the live sandbox.
- Removed `modal.Dict` paths and the `modal.forward(8080)` tunnel branch (+ `_tunnel*` attrs and their `end()` cleanup, which now terminates lingering sandboxes).

### `tests/unit/test_modal_executor.py`
- Rewritten to mock `Sandbox.create` + `exec`/`poll`. Covers execute_async (CLI + workload), sync success/failed/pending, and log readback. `MockTaskInstanceKey` gains `map_index=-1`.

## Testing
- `uv run pytest` → 6 passed.
- E2E skipped per coordinator instructions (shared Modal resources); coordinator runs full E2E after merge.

## Note
The assignment described `create_task_sandbox` running the task command as the sandbox entrypoint. A sandbox finishes (and becomes unreachable) the moment its entrypoint exits, which would make post-completion log readback impossible. Switched to the proven `sleep infinity` + `sandbox.exec(...)` pattern from `tests/system/test_app.py` so the sandbox stays alive for log readback before `terminate()`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)